### PR TITLE
chore(release): bump v1.0.1 → v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.0] - 2026-06-02
+
+> SceneFab v1.1.0 — 大型架构重构与质量改进
+
+### 🚀 Improvements
+
+- **8-Phase 架构重构** — 消除重复类型定义、清理冗余兼容层、拆分大文件、统一枚举与命名
+  - Phase 1: 合并 5 个重复类型定义 (EmotionType / ServiceStatus / ServiceHealth / AIServiceManager / ProjectMetadata)
+  - Phase 2: 删除 6 个冗余兼容层 (engine / models / ai_services / config_manager / exporters / video)
+  - Phase 3: 拆分 5 个 500+ 行 UI 大文件 (theme_optimizer / home_page / step_group / export_panel / export_monitor)
+  - Phase 4: 删除 ~160 行死代码 (`run_mashup` / `run_monologue` / `_analyze_single_frame`)
+  - Phase 5: 命名规范化 (`_signals.py` → `signals_bridge.py`, 10 个枚举集中到 `models/enums.py`)
+  - Phase 6: 配置精简 (删除 `.flake8`/`.pylintrc`, ruff 统一为唯一 linter, pyright 取消 UI 排除)
+  - Phase 7+8: UI 枚举导出 + 最终验收
+- **启用 ruff `UP` (pyupgrade) 规则** — 自动修复 1573 个 UP 错误 (typing.Dict/List → dict/list, 旧语法糖)
+- **依赖审计** — 同步 `requirements.txt` 与 `pyproject.toml`, 移除冗余工具 (googletrans / flake8 / isort), 升级 PySide6 6.9.0 / pydantic 2.5.0
+
+### 🔧 Internal
+
+- **CI 流水线**: PR Check 双 job (lint + test), merge-queue 友好
+- **代码质量门禁**: ruff 0 errors, pytest 351 passed + 20 skipped
+
+### 📦 Compatibility
+
+- **完全向后兼容 v1.0.x** — 所有公共 API 与 import 路径保持不变
+- **无破坏性变更** — 已发布的 v1.0.x 项目文件可直接打开
+
+---
+
 ## [1.0.1] - 2026-05-31
 
 > SceneFab v1.0.1 — 修复 GUI 启动问题

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scenefab"
-version = "1.0.1"
+version = "1.1.0"
 description = "SceneFab - AI 影视解说视频创作工具，一键完成智能拆条 · 解说生成 · 配音合成"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/scenefab/__init__.py
+++ b/src/scenefab/__init__.py
@@ -1,3 +1,3 @@
 # SceneFab - AI 视频解说工具
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "SceneFab Team"


### PR DESCRIPTION
## Release v1.1.0

> 大型架构重构与质量改进 — SceneFab 第二个稳定版本

### 📦 Changes (3 files, +31/-2)

| File | Change |
|------|--------|
| `pyproject.toml` | version 1.0.1 → 1.1.0 |
| `src/scenefab/__init__.py` | `__version__` fallback 1.0.0 → 1.1.0 |
| `CHANGELOG.md` | 新增 1.1.0 条目 |

### 🎯 Highlights (见 CHANGELOG.md)

- **8-Phase 架构重构** — 消除重复类型 + 清理兼容层 + 拆分大文件 + 命名规范化 + 配置精简
- **ruff `UP` 规则启用** — 自动修复 1573 个 pyupgrade 错误
- **依赖审计** — 移除冗余工具, 升级 PySide6/pydantic
- **Phase 3 拆分** — 5 个 500+ 行 UI 文件已拆 (theme_optimizer/home_page/step_group/export_panel/export_monitor)

### 🔒 Compatibility

- ✅ 完全向后兼容 v1.0.x — 所有公共 API 不变
- ✅ CI 0 errors, pytest 351 passed

### 📋 Post-merge

- [ ] 打 git tag `v1.1.0`
- [ ] 触发 PyPI 自动发布 (release workflow)