### PR TITLE
docs(badges): replace img.shields.io with native self-hosted SVG badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,5 +384,8 @@ ARCHITECTURE.md
 _DEAD/
 
 # Build artifacts
-docs/
-assets/
+docs/build/
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+assets/build/
+assets/dist/

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 > **上传一部电影 → AI 自动完成语义拆条、解说稿、配音、字幕、合成导出**
 > 从「几天一条」变成「一天十条」。
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](LICENSE)
-[![Python](https://img.shields.io/badge/Python-3.10+-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
-[![PySide6](https://img.shields.io/badge/Qt-6.9+-41C845?style=for-the-badge&logo=qt&logoColor=white)](https://qt.io/)
-[![Platform](https://img.shields.io/badge/Platform-Win%20%7C%20macOS%20%7C%20Linux-silver?style=for-the-badge)](https://github.com/Agions/scene-fab/releases)
-[![Version](https://img.shields.io/badge/v1.1.0-10B981?style=for-the-badge)](https://github.com/Agions/scene-fab/releases)
+[![License: MIT](assets/badges/license-mit.svg)](LICENSE)
+[![Python](assets/badges/python.svg)](https://www.python.org/)
+[![PySide6](assets/badges/pyside6.svg)](https://qt.io/)
+[![Platform](assets/badges/platform.svg)](https://github.com/Agions/scene-fab/releases)
+[![Version](assets/badges/version.svg)](https://github.com/Agions/scene-fab/releases)
 
 [**在线文档**](https://agions.github.io/scene-fab/) · [**下载安装**](https://github.com/Agions/scene-fab/releases) · [**报告问题**](https://github.com/Agions/scene-fab/issues/new) · [**功能建议**](https://github.com/Agions/scene-fab/discussions)
 
@@ -239,3 +239,13 @@ SceneFab 的诞生离不开以下开源项目：
 ⭐ 如果 SceneFab 对你有帮助，请给一个 Star · 🐛 遇到问题请提交 [Issue](https://github.com/Agions/scene-fab/issues)
 
 </div>
+
+<!--
+徽标说明：本仓库 README 中所有徽标均为自托管 SVG（位于 `assets/badges/`），
+不依赖任何第三方徽标服务（如 shields.io）。优势：
+  - 100% 离线可用（无外网请求）
+  - 零隐私追踪
+  - 风格与 SceneFab logo 系统统一（橙红渐变对应主题色）
+  - Version 徽标由 `scripts/generate_badges.py` 自动从 `pyproject.toml` 同步
+维护说明：bump 版本时运行 `python scripts/generate_badges.py` 即可。
+-->

--- a/assets/badges/license-mit.svg
+++ b/assets/badges/license-mit.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="28" role="img" aria-label="License: MIT">
+  <title>License: MIT</title>
+  <defs>
+    <linearGradient id="bgLicense" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValueLicense" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgLicense)"/>
+    <rect x="44" width="54" height="28" rx="4" ry="4" fill="url(#bgValueLicense)"/>
+    <!-- Cover the right side's left rounded edge -->
+    <rect x="40" width="8" height="28" fill="url(#bgValueLicense)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">License</text>
+    <text x="71" y="18">MIT</text>
+  </g>
+</svg>

--- a/assets/badges/platform.svg
+++ b/assets/badges/platform.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="28" role="img" aria-label="Platform: Windows macOS Linux">
+  <title>Platform: Win | macOS | Linux</title>
+  <defs>
+    <linearGradient id="bgPlatform" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePlatform" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#9CA3AF"/>
+      <stop offset="100%" stop-color="#6B7280"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPlatform)"/>
+    <rect x="44" width="116" height="28" rx="4" ry="4" fill="url(#bgValuePlatform)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePlatform)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">Platform</text>
+    <text x="102" y="18">Win | macOS | Linux</text>
+  </g>
+</svg>

--- a/assets/badges/pyside6.svg
+++ b/assets/badges/pyside6.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="28" role="img" aria-label="PySide6 Qt 6.9">
+  <title>PySide6 Qt 6.9+</title>
+  <defs>
+    <linearGradient id="bgPySide" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePySide" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#52C752"/>
+      <stop offset="100%" stop-color="#2E8B2E"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPySide)"/>
+    <rect x="44" width="72" height="28" rx="4" ry="4" fill="url(#bgValuePySide)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePySide)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">PySide6</text>
+    <text x="80" y="18">Qt 6.9</text>
+  </g>
+</svg>

--- a/assets/badges/python.svg
+++ b/assets/badges/python.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="28" role="img" aria-label="Python 3.10+">
+  <title>Python 3.10+</title>
+  <defs>
+    <linearGradient id="bgPython" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePython" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#41A5DB"/>
+      <stop offset="100%" stop-color="#2B7CB3"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPython)"/>
+    <rect x="44" width="72" height="28" rx="4" ry="4" fill="url(#bgValuePython)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePython)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">Python</text>
+    <text x="80" y="18">3.10+</text>
+  </g>
+</svg>

--- a/assets/badges/version.svg
+++ b/assets/badges/version.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="28" role="img" aria-label="SceneFab v1.1.0">
+  <title>SceneFab v1.1.0</title>
+  <defs>
+    <linearGradient id="bgVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValueVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgVersion)"/>
+    <rect x="44" width="54" height="28" rx="4" ry="4" fill="url(#bgValueVersion)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValueVersion)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">version</text>
+    <text x="71" y="18">v1.1.0</text>
+  </g>
+</svg>

--- a/docs/public/badges/license-mit.svg
+++ b/docs/public/badges/license-mit.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="28" role="img" aria-label="License: MIT">
+  <title>License: MIT</title>
+  <defs>
+    <linearGradient id="bgLicense" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValueLicense" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#4F46E5"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgLicense)"/>
+    <rect x="44" width="54" height="28" rx="4" ry="4" fill="url(#bgValueLicense)"/>
+    <!-- Cover the right side's left rounded edge -->
+    <rect x="40" width="8" height="28" fill="url(#bgValueLicense)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">License</text>
+    <text x="71" y="18">MIT</text>
+  </g>
+</svg>

--- a/docs/public/badges/platform.svg
+++ b/docs/public/badges/platform.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="28" role="img" aria-label="Platform: Windows macOS Linux">
+  <title>Platform: Win | macOS | Linux</title>
+  <defs>
+    <linearGradient id="bgPlatform" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePlatform" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#9CA3AF"/>
+      <stop offset="100%" stop-color="#6B7280"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPlatform)"/>
+    <rect x="44" width="116" height="28" rx="4" ry="4" fill="url(#bgValuePlatform)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePlatform)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">Platform</text>
+    <text x="102" y="18">Win | macOS | Linux</text>
+  </g>
+</svg>

--- a/docs/public/badges/pyside6.svg
+++ b/docs/public/badges/pyside6.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="28" role="img" aria-label="PySide6 Qt 6.9">
+  <title>PySide6 Qt 6.9+</title>
+  <defs>
+    <linearGradient id="bgPySide" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePySide" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#52C752"/>
+      <stop offset="100%" stop-color="#2E8B2E"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPySide)"/>
+    <rect x="44" width="72" height="28" rx="4" ry="4" fill="url(#bgValuePySide)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePySide)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">PySide6</text>
+    <text x="80" y="18">Qt 6.9</text>
+  </g>
+</svg>

--- a/docs/public/badges/python.svg
+++ b/docs/public/badges/python.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="28" role="img" aria-label="Python 3.10+">
+  <title>Python 3.10+</title>
+  <defs>
+    <linearGradient id="bgPython" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValuePython" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#41A5DB"/>
+      <stop offset="100%" stop-color="#2B7CB3"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgPython)"/>
+    <rect x="44" width="72" height="28" rx="4" ry="4" fill="url(#bgValuePython)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValuePython)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">Python</text>
+    <text x="80" y="18">3.10+</text>
+  </g>
+</svg>

--- a/docs/public/badges/version.svg
+++ b/docs/public/badges/version.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="28" role="img" aria-label="SceneFab v1.1.0">
+  <title>SceneFab v1.1.0</title>
+  <defs>
+    <linearGradient id="bgVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValueVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgVersion)"/>
+    <rect x="44" width="54" height="28" rx="4" ry="4" fill="url(#bgValueVersion)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValueVersion)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">version</text>
+    <text x="71" y="18">v1.1.0</text>
+  </g>
+</svg>

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate SceneFab version badge SVG from pyproject.toml.
+
+Usage:
+    python scripts/generate_badges.py
+    python scripts/generate_badges.py --version 1.2.0
+    python scripts/generate_badges.py --check   # CI check (fail if drift)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+BADGE_PATH = ROOT / "assets" / "badges" / "version.svg"
+
+
+def read_pyproject_version() -> str:
+    """Extract `version = "X.Y.Z"` from pyproject.toml."""
+    if not PYPROJECT.exists():
+        sys.exit(f"❌ pyproject.toml not found at {PYPROJECT}")
+    content = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if not match:
+        sys.exit(f"❌ No version field found in {PYPROJECT}")
+    return match.group(1)
+
+
+def render_version_badge(version: str) -> str:
+    """Render the version badge SVG with the given version string."""
+    svg = f'''<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="28" role="img" aria-label="SceneFab v{version}">
+  <title>SceneFab v{version}</title>
+  <defs>
+    <linearGradient id="bgVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#555555"/>
+      <stop offset="100%" stop-color="#333333"/>
+    </linearGradient>
+    <linearGradient id="bgValueVersion" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <g shape-rendering="crispEdges">
+    <rect width="44" height="28" rx="4" ry="4" fill="url(#bgVersion)"/>
+    <rect x="44" width="54" height="28" rx="4" ry="4" fill="url(#bgValueVersion)"/>
+    <rect x="40" width="8" height="28" fill="url(#bgValueVersion)"/>
+  </g>
+  <g font-family="Verdana, Geneva, Tahoma, sans-serif" font-weight="700" font-size="11" text-anchor="middle" fill="#ffffff">
+    <text x="22" y="18">version</text>
+    <text x="71" y="18">v{version}</text>
+  </g>
+</svg>
+'''
+    return svg
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate SceneFab version badge.")
+    parser.add_argument(
+        "--version", help="Override version (default: read from pyproject.toml)"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="CI check: exit 1 if badge is out of sync with pyproject.toml",
+    )
+    args = parser.parse_args()
+
+    version = args.version or read_pyproject_version()
+
+    if args.check:
+        if not BADGE_PATH.exists():
+            print(f"❌ Badge not found at {BADGE_PATH}")
+            return 1
+        existing = BADGE_PATH.read_text(encoding="utf-8")
+        expected = render_version_badge(version)
+        if existing == expected:
+            print(f"✅ Badge in sync (v{version})")
+            return 0
+        print(f"❌ Badge drift: expected v{version}, file is out of sync")
+        print(f"   Run: python scripts/generate_badges.py")
+        return 1
+
+    BADGE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BADGE_PATH.write_text(render_version_badge(version), encoding="utf-8")
+    print(f"✅ Wrote {BADGE_PATH} (v{version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 徽标原生化 (Self-hosted Badges)

> 移除所有 `img.shields.io` 第三方徽标服务依赖, 改用 SceneFab 自托管 SVG 徽标

### 🎯 Why

`shields.io` 适合原型, 但对 ship 出去的产品有实际风险:

- **宕机暴露** — shields.io 挂掉 = README 5 个徽标全变红 X
- **网络依赖** — 离线/防火墙后用户看到破图
- **隐私泄漏** — 每次 README 浏览都向第三方 CDN 发送带 UA/Referer 请求
- **风格漂移** — 第三方渲染规则随时可能变
- **品牌不一致** — 颜色字体不匹配 SceneFab 3 色 logo 系统

### 🎨 5 个自托管 SVG 徽标

| 徽标 | 路径 | 配色 |
|------|------|------|
| License: MIT | `assets/badges/license-mit.svg` | Indigo 渐变 (`#6366F1 → #4F46E5`) |
| Python 3.10+ | `assets/badges/python.svg` | Python 蓝 (`#41A5DB → #2B7CB3`) |
| PySide6 Qt 6.9 | `assets/badges/pyside6.svg` | Qt 绿 (`#52C752 → #2E8B2E`) |
| Platform | `assets/badges/platform.svg` | 中性灰 (`#9CA3AF → #6B7280`) |
| Version v1.1.0 | `assets/badges/version.svg` | **SceneFab 品牌橙红** (`#ff8a5b → #e63946`) |

**统一规格**: 28px 高, for-the-badge 风格, Verdana 11px 粗体, 全部含 `role="img"` + `aria-label` + `<title>` (无障碍)

### 🤖 自动化

新增 `scripts/generate_badges.py` 从 `pyproject.toml` 读 version 自动生成 version 徽标:

```bash
python scripts/generate_badges.py            # 重新生成
python scripts/generate_badges.py --check    # CI: 不同步则 exit 1
```

### 🔧 附带修复 .gitignore

旧 `docs/` + `assets/` 规则太宽 (阻止任何资源目录被 track), 改为精确 build-output 规则:
- `docs/build/`
- `docs/.vitepress/dist/`
- `docs/.vitepress/cache/`
- `assets/build/`
- `assets/dist/`

### 📋 文件清单

- 5 新徽标 SVG: `assets/badges/*.svg`
- 5 同步副本: `docs/public/badges/*.svg` (VitePress 文档站)
- 1 新生成脚本: `scripts/generate_badges.py`
- README.md: 5 个 shields.io URL → 5 个本地 SVG 路径 + 决策说明 HTML 注释
- .gitignore: build 规则精确化

### ✅ 验证

- [x] 5 个 SVG 全部 XML valid
- [x] `ruff check src/scenefab/` 0 errors
- [x] `generate_badges.py --check` v1.1.0 同步
- [x] `rg img.shields.io` 无残留
- [x] README 路径全部 resolve 到 assets/badges/

### 📋 Post-merge (可选 TODO)

- [ ] 加 pre-commit hook: `python scripts/generate_badges.py --check`
- [ ] Release workflow 调用 `generate_badges.py` 自动同步 version 徽标
- [ ] 考虑把 logo + badges 打包成 npm-style icon library