### PR TITLE
refactor(ffmpeg): 合并双执行器 — SafeFFmpegCommand 委托 SecureExecutor

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -72,7 +72,9 @@ v2.2 周期内将 `video_exporter.py` 的真实实现抽空、仅保留转发到
 
 **仍保留的裸 subprocess（合法）**：`core/ffmpeg_safe.py`(执行器自身) · `utils/security.py`(`SecureExecutor`) · `ffmpeg_tool.py` 的 `nvidia-smi`/`wmic`（非 ffmpeg 能力探测，不在白名单内）。
 
-**未做（本轮范围外）**：`core/ffmpeg_safe.SafeFFmpegCommand`（仅 3 处用）与 `SecureExecutor` 的双执行器并存未合并；硬件检测/ffprobe 元数据/命令构建未从 `FFmpegTool` 拆为独立模块。留待后续。
+**双执行器合并（2026-06-16 后续完成）**：`core/ffmpeg_safe.SafeFFmpegCommand.execute()` 原有独立 `subprocess.run`，现委托 `utils.security.SecureExecutor`（统一底座）。`SafeFFmpegCommand` 保留声明式命令构建 + 校验 + `FFmpegResult`/审计封装，但不再持有第二条执行路径。`SecureExecutor` 将超时/失败包装为 `SecurityError`；`execute()` 按原契约还原（超时 → `TimeoutExpired`，非零 rc → `FFmpegResult(success=False)`）。
+
+**仍未做**：硬件检测/ffprobe 元数据/命令构建未从 `FFmpegTool` 拆为独立模块。留待后续。
 
 ## 6. 并发与生命周期 (P4，2026-06-16)
 

--- a/src/scenefab/core/ffmpeg_safe.py
+++ b/src/scenefab/core/ffmpeg_safe.py
@@ -8,7 +8,8 @@ FFmpeg 安全封装 — v2.0 重构
 - 参数白名单（codec / preset / crf / 滤镜）
 - 路径安全检查（禁止写入系统目录）
 - 危险字符检测（; & | ` $ ( ) 等）
-- 使用 subprocess list 模式（非 shell）
+- 执行统一委托给 `utils.security.SecureExecutor`（单一安全执行底座，
+  list 模式非 shell），本模块只负责声明式命令构建 + 结果/审计封装
 - 审计日志自动集成
 
 使用示例:
@@ -336,20 +337,18 @@ class SafeFFmpegCommand:
         if audit:
             self._log_execute_start()
 
+        # 统一执行入口：复用全局安全执行器底座（不再各自 subprocess.run）
+        from scenefab.utils.security import SecurityError, get_ffmpeg_executor
+
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout_sec,
-                check=False,
-                # 关键：不用 shell=True
-            )
+            result = get_ffmpeg_executor().run(cmd, timeout=self.timeout_sec)
             return self._build_result(result, cmd, start_ms, audit)
-        except subprocess.TimeoutExpired:
-            self._handle_timeout(start_ms, audit)
-            raise
-        except Exception as e:
+        except SecurityError as e:
+            # SecureExecutor 将超时/执行失败统一包装为 SecurityError。
+            # 超时单独审计后按原契约重新抛出 TimeoutExpired，其余按执行错误处理。
+            if "超时" in str(e):
+                self._handle_timeout(start_ms, audit)
+                raise subprocess.TimeoutExpired(cmd, self.timeout_sec) from e
             self._handle_execution_error(e, start_ms, audit)
             raise
 

--- a/tests/test_core_v2.py
+++ b/tests/test_core_v2.py
@@ -372,6 +372,49 @@ class TestSafeFFmpegCommand:
         finally:
             input_path.unlink()
 
+    def test_execute_routes_through_secure_executor(self):
+        """execute() 委托统一安全执行器（不再自带 subprocess.run）。"""
+        import subprocess
+
+        from scenefab.core.ffmpeg_safe import FFmpegResult, SafeFFmpegCommand
+
+        with tempfile.TemporaryDirectory() as d:
+            inp = Path(d) / "in.mp4"
+            inp.write_bytes(b"x")
+            out = Path(d) / "out.mp4"
+
+            def mk():
+                return SafeFFmpegCommand(
+                    input_file=inp, output_file=out, timeout_sec=600
+                )
+
+            # 成功：经 SecureExecutor.run 返回 CompletedProcess → FFmpegResult
+            cp = subprocess.CompletedProcess(["ffmpeg"], 0, "ok", "")
+            with patch(
+                "scenefab.utils.security.SecureExecutor.run", return_value=cp
+            ) as m:
+                r = mk().execute(audit=False)
+                assert isinstance(r, FFmpegResult) and r.success
+                assert m.called and isinstance(m.call_args[0][0], list)
+
+            # 非零返回码 → FFmpegResult(success=False)，不抛
+            cp_fail = subprocess.CompletedProcess(["ffmpeg"], 1, "", "boom")
+            with patch(
+                "scenefab.utils.security.SecureExecutor.run", return_value=cp_fail
+            ):
+                r2 = mk().execute(audit=False)
+                assert not r2.success and r2.returncode == 1
+
+            # 超时（SecureExecutor 抛 SecurityError"超时"）→ 按原契约重抛 TimeoutExpired
+            from scenefab.utils.security import SecurityError
+
+            with patch(
+                "scenefab.utils.security.SecureExecutor.run",
+                side_effect=SecurityError("命令执行超时: 600秒"),
+            ):
+                with pytest.raises(subprocess.TimeoutExpired):
+                    mk().execute(audit=False)
+
     def test_is_safe_path(self):
         from scenefab.core.ffmpeg_safe import is_safe_path
 


### PR DESCRIPTION
## 概述

合并双 FFmpeg 执行器（P3 当初有意跳过的遗留项）。

> **Stacked on #71** — base 为 `chore/p0-p1-baseline`。#71 合并后本 PR base 会自动变为 `main`，届时仅剩 1 笔净改动。

## 改动

此前存在两个并行的执行原语：
- `utils.security.SecureExecutor.run`（51 处使用，事实底座）
- `core.ffmpeg_safe.SafeFFmpegCommand.execute`（自带独立 `subprocess.run`，1 处生产使用）

本 PR 让 `SafeFFmpegCommand.execute()` 委托 `SecureExecutor`，消除第二条执行路径：
- 保留声明式命令构建 + 白名单校验 + `FFmpegResult`/审计封装
- 按原契约还原异常语义：超时 → `TimeoutExpired`，非零 rc → `FFmpegResult(success=False)`
- 唯一生产消费方 `platform_adapter` 行为不变

## 验收

- ruff 通过
- pytest 594 passed / 11 skipped（新增 `test_execute_routes_through_secure_executor` 覆盖成功/失败/超时三路径）

## 仍未做（记入 deprecations.md）

硬件检测 / ffprobe 元数据 / 命令构建未从 `FFmpegTool` 拆为独立模块。
