### PR TITLE
refactor(pipeline): PipelineEngine 不可变输入上下文 + 中央结果归并

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -385,3 +385,6 @@ _DEAD/
 # Build artifacts
 docs/
 assets/
+
+
+.claude

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -86,7 +86,7 @@ v2.2 周期内将 `video_exporter.py` 的真实实现抽空、仅保留转发到
   - **可取消退避**：重试 `time.sleep(backoff)` → `self._shutdown.wait(backoff)`，关闭时立即返回。
   - `shutdown()` 用 `executor.shutdown(cancel_futures=True)` 取消未开始任务。
   - 公开 API（`start`/`wait_until_done`/`shutdown`/`summary`/`pipeline_factory`/回调/checkpoint）保持不变。
-- **未做（本轮范围外）**：PipelineEngine 改不可变输入上下文 + step 返回结果集中归并——会改变 `ctx["steps"]` 公开契约，风险最大且 PipelineEngine 暂无生产调用方，留待后续。
+- **PipelineEngine 不可变上下文（2026-06-16 后续完成，见 §9）**。
 
 ## 7. 命名规范化 (P5，2026-06-16)
 
@@ -118,6 +118,18 @@ v2.2 周期内将 `video_exporter.py` 的真实实现抽空、仅保留转发到
 2. 自绘 `StatusBar(QFrame)` 传给 `QMainWindow.setStatusBar()`（要求 `QStatusBar`）→ 改入中央垂直布局底部。
 
 **验收基线**：默认 `pytest` 无需 `PYTHONPATH=src`、无需 Qt binding、无需任何环境变量即可得到 593 passed 的可解释结果（P0 契约成立）。
+
+## 9. PipelineEngine 不可变输入上下文 (2026-06-16)
+
+`core/pipeline_engine.py` 原模型：调度器把共享可变 `context`（含被并发写的 `context["steps"]`）整体传给每个 `step.func`，step 内对 `steps` 的读不加锁，与其他并行 step 的写形成 race。
+
+改为**不可变输入 + 中央归并**：
+- 新增权威结果存储 `PipelineEngine._completed_outputs`（加锁写）。
+- `_run_step_function` 给每个 step 传入一份输入视图，其中 `steps` 是当时已完成结果的只读快照（`MappingProxyType`）。step 依赖全部 COMPLETED 才 ready，故快照必含其依赖结果，语义不变。
+- step 返回值由 `_postprocess_step_success` 集中归并到 `_completed_outputs`，不再写进 step 收到的 context。
+- `run()` 末尾把 `_completed_outputs` 汇总进返回 `context["steps"]`，公开输出契约不变；`run()` 入口重置该存储以支持复用。
+
+**BREAKING（内部）**：`step.func` 不能再写 `ctx["steps"]` 影响全局结果（写只读快照抛 `TypeError`）；下游只能读已完成依赖的结果快照。PipelineEngine 无生产调用方（仅 `test_core_v2.py`；`narration_state_machine.py` 中为 docstring 示例），故仅文档化。
 
 ---
 

--- a/src/scenefab/core/pipeline_engine.py
+++ b/src/scenefab/core/pipeline_engine.py
@@ -48,6 +48,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
+from types import MappingProxyType
 from typing import Any
 
 # v2.1: 领域事件发布（可选，未注入则跳过）
@@ -163,6 +164,9 @@ class PipelineEngine:
         self.steps: dict[str, PipelineStep] = {}
         self.states: dict[str, StepStatus] = {}
         self.results: dict[str, StepResult] = {}
+        # 权威结果存储：step 返回值集中归并于此（加锁写），
+        # 不再让 step 直接写共享 context["steps"]（不可变输入契约）
+        self._completed_outputs: dict[str, Any] = {}
         self._lock = __import__("threading").RLock()
         self._audit = AuditLogger()
         # v2.1: 事件总线（None 时不发布事件）
@@ -243,6 +247,9 @@ class PipelineEngine:
         context = dict(context or {})
         context.setdefault("input", {})
         context.setdefault("steps", {})
+        # 重置权威结果存储（支持引擎复用 / 重跑）
+        with self._lock:
+            self._completed_outputs = {}
 
         logger.info(
             f"Pipeline start: {len(self.steps)} steps, "
@@ -274,6 +281,10 @@ class PipelineEngine:
             duration_ms=total_duration,
             error_message=f"{failed} steps failed" if failed else "",
         )
+
+        # 中央归并：把权威结果汇总进返回 context（公开输出契约不变）
+        with self._lock:
+            context["steps"].update(self._completed_outputs)
 
         return context
 
@@ -484,8 +495,24 @@ class PipelineEngine:
         return start_time
 
     def _run_step_function(self, step: PipelineStep, context: dict) -> Any:
-        """Invoke the step's user function. Exceptions propagate."""
-        return step.func(context)
+        """Invoke the step's user function with an immutable input view.
+
+        step 收到的 context 中 `steps` 是当时已完成结果的只读快照
+        （`MappingProxyType`），消除并发读写 race，并禁止 step 静默污染
+        全局结果存储。step 的输出通过返回值由调度器集中归并。
+        """
+        step_ctx = self._build_step_input(context)
+        return step.func(step_ctx)
+
+    def _build_step_input(self, context: dict) -> dict:
+        """构造传给 step 的不可变输入视图（提交时刻快照）。"""
+        with self._lock:
+            steps_snapshot = MappingProxyType(dict(self._completed_outputs))
+        step_ctx = {
+            k: v for k, v in context.items() if k != "steps"
+        }
+        step_ctx["steps"] = steps_snapshot
+        return step_ctx
 
     def _postprocess_step_success(
         self,
@@ -505,7 +532,8 @@ class PipelineEngine:
                 duration_ms=duration_ms,
                 start_time=start_time,
             )
-            context["steps"][step.id] = output
+            # 中央归并：写入权威结果存储，而非 step 收到的（只读）context
+            self._completed_outputs[step.id] = output
 
         self._audit.log_action(
             action="pipeline_step_done",

--- a/tests/test_core_v2.py
+++ b/tests/test_core_v2.py
@@ -278,6 +278,42 @@ class TestPipelineEngine:
         # 验证 cleanup 步骤被标记为 COMPLETED
         assert engine.get_state("cleanup") == StepStatus.COMPLETED
 
+    def test_step_receives_immutable_steps_snapshot(self):
+        """step 收到只读 steps 快照：可读已完成依赖结果，写入抛错。"""
+        from scenefab.core.pipeline_engine import PipelineEngine, PipelineStep
+
+        engine = PipelineEngine(max_workers=2)
+        captured = {}
+
+        def upstream(ctx):
+            return "up_value"
+
+        def downstream(ctx):
+            # 可读到已完成依赖的结果
+            captured["dep"] = ctx["steps"]["up"]
+            # 写只读快照应抛 TypeError（MappingProxyType）
+            try:
+                ctx["steps"]["x"] = 1
+                captured["write_blocked"] = False
+            except TypeError:
+                captured["write_blocked"] = True
+            return "down_value"
+
+        engine.add_step(PipelineStep(id="up", func=upstream))
+        engine.add_step(
+            PipelineStep(id="down", func=downstream, dependencies=["up"])
+        )
+
+        result = engine.run({})
+
+        assert captured["dep"] == "up_value"  # 中央归并的依赖结果可读
+        assert captured["write_blocked"] is True  # 只读快照禁止写
+        # 公开输出契约不变
+        assert result["steps"]["up"] == "up_value"
+        assert result["steps"]["down"] == "down_value"
+        # step 写 ctx["steps"] 未污染权威结果
+        assert "x" not in result["steps"]
+
 
 # === SafeFFmpegCommand ===
 


### PR DESCRIPTION
## 概述

PipelineEngine 改为不可变输入上下文（当初 P4 有意跳过的最高风险遗留项）。

## 问题

原模型：调度器把共享可变 `context`（含被并发写的 `context["steps"]`）整体传给每个 `step.func`。step 内对 `steps` 的读不加锁，与其他并行 step 的写形成 data race；step 还能静默污染全局结果存储。

## 改动

不可变输入 + 中央归并：
- 新增权威结果存储 `_completed_outputs`（加锁中央归并）
- 每个 step 收到的 `context["steps"]` 改为已完成依赖结果的**只读快照**（`MappingProxyType`）—— step 依赖全部 COMPLETED 才 ready，快照必含其依赖结果，语义不变
- step 返回值集中归并到 `_completed_outputs`；`run()` 末尾汇总进返回 `context["steps"]`，**公开输出契约不变**；`run()` 入口重置以支持引擎复用

## 契约变更（内部 BREAKING）

`step.func` 不能再写 `ctx["steps"]` 影响全局（写只读快照抛 `TypeError`）；下游只能读已完成依赖结果。PipelineEngine 无生产调用方（仅 `test_core_v2.py` + docstring 示例），仅文档化（deprecations.md §9）。

## 验收

- ruff 通过
- pytest 595 passed / 11 skipped（新增 `test_step_receives_immutable_steps_snapshot` 覆盖：读依赖快照 / 写只读抛错 / 不污染权威结果）