### PR TITLE
fix(mypy): 移除 7 处失效 type:ignore 修复 type-check baseline gate

### DIFF
--- a/src/scenefab/plugins/examples/deepseek_ai_generator/deepseek_gen.py
+++ b/src/scenefab/plugins/examples/deepseek_ai_generator/deepseek_gen.py
@@ -35,11 +35,11 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
 
     def _on_enable(self) -> None:
         """启用时的回调"""
-        self.log_info("DeepSeek AI Generator plugin enabled")  # type: ignore[attr-defined]
+        self.log_info("DeepSeek AI Generator plugin enabled")
 
     def _on_disable(self) -> None:
         """禁用时的回调"""
-        self.log_info("DeepSeek AI Generator plugin disabled")  # type: ignore[attr-defined]
+        self.log_info("DeepSeek AI Generator plugin disabled")
 
     def get_provider_name(self) -> str:
         """获取 AI Provider 名称"""
@@ -79,7 +79,7 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
             scenes = self._parse_scene_analysis_response(response, frame_timestamps)
             return scenes
         except Exception as e:
-            self.log_error(f"Scene analysis failed: {e}")  # type: ignore[attr-defined]
+            self.log_error(f"Scene analysis failed: {e}")
             # 返回空列表或可以返回部分结果
             return []
 
@@ -128,7 +128,7 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
                         )
                         scenes.append(scene)
         except Exception as e:
-            self.log_error(f"Failed to parse scene analysis response: {e}")  # type: ignore[attr-defined]
+            self.log_error(f"Failed to parse scene analysis response: {e}")
 
         # 如果解析失败，生成默认场景
         if not scenes:
@@ -174,7 +174,7 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
             response = await self._call_deepseek_api(prompt)
             return self._parse_script_generation_response(response)
         except Exception as e:
-            self.log_error(f"Script generation failed: {e}")  # type: ignore[attr-defined]
+            self.log_error(f"Script generation failed: {e}")
             return ScriptGeneration(
                 script_id=str(uuid.uuid4()),
                 text="脚本生成失败，请稍后重试。",
@@ -221,7 +221,7 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
                     style_tags=data.get("style_tags", []),
                 )
         except Exception as e:
-            self.log_error(f"Failed to parse script generation response: {e}")  # type: ignore[attr-defined]
+            self.log_error(f"Failed to parse script generation response: {e}")
 
         # 降级处理
         return ScriptGeneration(
@@ -252,7 +252,7 @@ class DeepSeekAIGeneratorPlugin(BaseAIGeneratorPlugin):
             async for chunk in self._call_deepseek_api_stream(prompt):
                 yield chunk
         except Exception as e:
-            self.log_error(f"Script streaming failed: {e}")  # type: ignore[attr-defined]
+            self.log_error(f"Script streaming failed: {e}")
             yield "脚本生成失败，请稍后重试。"
 
     async def _call_deepseek_api(self, prompt: str) -> str:


### PR DESCRIPTION
## 问题
main 上 `type-check` job 的 mypy baseline gate 报 `111 > 105` 失败（job 为 continue-on-error，不阻塞合并，但显示红叉）。

## 根因
`deepseek_gen.py` 中 `self.log_info/log_error(...)` 上的 `# type: ignore[attr-defined]` 已失效——`log_info/log_error/log_warning` 在 `BaseAIGeneratorPlugin` 基类有具体类型定义，mypy 能正常解析。随 mypy/依赖版本漂移，这些 ignore 被判为 `unused-ignore`，错误数累积越过 baseline。

该文件非本轮重构改动，属预存 + 环境敏感问题。

## 修复
移除 7 处失效 `# type: ignore[attr-defined]`（log_* 调用），错误数回落 104 ≤ 105。

## 验证
workflow_dispatch 在本分支跑全量 ci.yml：lint / test(3.11) / test(3.12) / type-check **全绿**，`Mypy baseline OK (104 <= 105)`。