### PR TITLE
refactor(project): 项目格式/配置目录统一为 .scenefab（带向后兼容）

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -92,12 +92,19 @@ v2.2 周期内将 `video_exporter.py` 的真实实现抽空、仅保留转发到
 
 - **phase 文件/函数重命名**（见 §3）。
 - **文档版本修正**：`docs/guide/quick-start.md` / `installation.md` 的 `scenefab --version` 示例输出 `2.2.0` → `2.1.1`。ADR-007/006 中的 "v2.2" 指 narration 里程碑的设计记录，属历史文档，未改。
-- **`.narrafiilm` 拼写修正（带向后兼容）**：默认拼写改为 `.narrafilm`（narration+film，原双 i 为拼写遗留）。
-  - 项目文件扩展名：`ProjectManager.PROJECT_EXTENSION = ".narrafilm"`；`PROJECT_EXTENSIONS` 保留 `[".narrafilm", ".narrafiilm", ".vfproj"]`，旧文件仍可加载。
-  - 配置目录：默认 `~/.narrafilm`；若仅存在旧 `~/.narrafiilm` 则沿用，不孤立既有配置。
-  - 安全允许目录：同时收录新旧路径（`~/.narrafilm` + `~/.narrafiilm`，`/etc/narrafilm` + `/etc/narrafiilm`）。
-  - 内部符号 `_NarrafiilmVersion` → `_NarrafilmVersion`（内部 API，无外部消费方）。
-  - **待移除**：旧 `.narrafiilm` 扩展名/配置目录的兼容读取，建议 **v2.3.0** 移除。
+- **`.narrafiilm` 拼写修正（带向后兼容）**：P5 先将默认拼写从 `.narrafiilm` 改为 `.narrafilm`。**后续（见 §9）进一步统一为 `.scenefab`，与产品名一致。**
+  - 内部符号 `_NarrafiilmVersion` → `_NarrafilmVersion`（后续再 → `_ProjectFileVersion`）。
+
+## 9. 项目格式与配置目录统一为 .scenefab (2026-06-16)
+
+将项目文件扩展名 / 配置目录从 `.narrafilm` 统一为 `.scenefab`，与产品名一致。**全程带向后兼容，不孤立既有用户文件/配置。**
+
+- **项目文件扩展名**：`ProjectManager.PROJECT_EXTENSION = ".scenefab"`；`PROJECT_EXTENSIONS = [".scenefab", ".narrafilm", ".narrafiilm", ".vfproj"]`（新文件存 `.scenefab`，旧 `.narrafilm`/`.narrafiilm` 仍可加载）。`monologue_maker.save` 默认后缀同步为 `.scenefab`。
+- **配置目录**：默认 `~/.scenefab`；新目录不存在但旧 `~/.narrafilm` / `~/.narrafiilm` 存在时，沿用最先命中的旧目录。
+- **安全允许目录**：补 `~/.scenefab` + `/etc/scenefab`，保留旧路径。
+- **内部符号**：`_NarrafilmVersion` → `_ProjectFileVersion`（产品中立命名，避免再次改名）；temp 前缀 `narrafilm_*` → `scenefab_*`。
+- 测试：新增 `tests/test_pipeline_project_manager.py` 覆盖默认扩展名 + 旧扩展名保留可加载。
+- **待移除**：旧 `.narrafilm` / `.narrafiilm` 扩展名与配置目录的兼容读取，建议 **v2.3.0** 一并移除。
 
 ## 8. 回归与交付门禁 (P6，2026-06-16)
 

--- a/src/scenefab/models/project_file_metadata.py
+++ b/src/scenefab/models/project_file_metadata.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
 """
-项目文件元数据（narrafilm 文件格式）
+项目文件元数据（.scenefab 项目文件格式）
 
 .. note::
-    本模块定义 .narrafilm 项目文件持久化时的元数据格式，与
+    本模块定义 .scenefab 项目文件持久化时的元数据格式，与
     ``scenefab.models.project_models.ProjectMetadata``（项目运行时元数据）
     是两个不同概念：
 
     - ``ProjectMetadata``：项目运行时元数据（用于项目管理器）
-    - ``ProjectFileMetadata``：项目文件元数据（用于 .narrafilm 文件格式）
+    - ``ProjectFileMetadata``：项目文件元数据（用于 .scenefab 文件格式）
 
 历史：原位于 ``scenefab.services.orchestration.pipeline_project_manager``，
 因与 ``models.project_models.ProjectMetadata`` 命名冲突，于 Phase 1 重构中
@@ -21,8 +21,8 @@ from enum import Enum
 from typing import Any
 
 
-class _NarrafilmVersion(Enum):
-    """narrafilm 项目文件版本（内部使用）"""
+class _ProjectFileVersion(Enum):
+    """.scenefab 项目文件版本（内部使用）"""
 
     V1 = "1.0"
     V2 = "2.0"  # 当前版本，支持更多元数据
@@ -30,9 +30,9 @@ class _NarrafilmVersion(Enum):
 
 @dataclass
 class ProjectFileMetadata:
-    """narrafilm 项目文件元数据
+    """.scenefab 项目文件元数据
 
-    用于 .narrafilm 项目文件的持久化与交换。
+    用于 .scenefab 项目文件的持久化与交换。
     """
 
     id: str = ""  # 项目唯一ID
@@ -64,4 +64,4 @@ class ProjectFileMetadata:
         return cls(**{k: v for k, v in data.items() if k in valid_fields})
 
 
-__all__ = ["ProjectFileMetadata", "_NarrafilmVersion"]
+__all__ = ["ProjectFileMetadata", "_ProjectFileVersion"]

--- a/src/scenefab/services/ai/subtitle_extractor.py
+++ b/src/scenefab/services/ai/subtitle_extractor.py
@@ -164,7 +164,7 @@ class OCRSubtitleExtractor:
         self, video_path: str, duration: float, interval: float, max_frames: int
     ) -> list[tuple[float, str]]:
         """提取关键帧"""
-        tmpdir = tempfile.mkdtemp(prefix="narrafilm_ocr_")
+        tmpdir = tempfile.mkdtemp(prefix="scenefab_ocr_")
         frames = []
         num = min(int(duration / interval) + 1, max_frames)
 

--- a/src/scenefab/services/ai/subtitle_speech.py
+++ b/src/scenefab/services/ai/subtitle_speech.py
@@ -264,7 +264,7 @@ class SpeechSubtitleExtractor:
         if ext in (".mp3", ".wav", ".m4a", ".flac", ".ogg", ".aac"):
             return video_path
 
-        fd, output = tempfile.mkstemp(suffix=".wav", prefix="narrafilm_stt_")
+        fd, output = tempfile.mkstemp(suffix=".wav", prefix="scenefab_stt_")
         os.close(fd)  # mkstemp 创建文件，ffmpeg 会覆盖它
         cmd = [
             "ffmpeg",

--- a/src/scenefab/services/orchestration/__init__.py
+++ b/src/scenefab/services/orchestration/__init__.py
@@ -28,7 +28,7 @@ from .pipeline_project_manager import (
     ProjectMetadata,
     ProjectSource,
     SceneFabProject,
-    _NarrafilmVersion,  # 仅内部使用，不对外公开
+    _ProjectFileVersion,  # 仅内部使用，不对外公开
     load_project,
     save_project,
 )
@@ -55,5 +55,5 @@ __all__ = [
     "SceneFabProject",
     "save_project",
     "load_project",
-    "_NarrafilmVersion",
+    "_ProjectFileVersion",
 ]

--- a/src/scenefab/services/orchestration/pipeline_project_manager.py
+++ b/src/scenefab/services/orchestration/pipeline_project_manager.py
@@ -3,7 +3,7 @@
 """
 SceneFab 项目文件管理
 
-支持 .narrafilm 项目文件的保存、加载和管理。
+支持 .scenefab 项目文件的保存、加载和管理（兼容旧 .narrafilm/.narrafiilm）。
 
 项目文件格式：
 - JSON 格式，易于阅读和调试
@@ -16,10 +16,10 @@ SceneFab 项目文件管理
     manager = ProjectManager()
 
     # 保存项目
-    manager.save(project, "my_video.narrafilm")
+    manager.save(project, "my_video.scenefab")
 
     # 加载项目
-    project = manager.load("my_video.narrafilm")
+    project = manager.load("my_video.scenefab")
 """
 
 import json
@@ -35,7 +35,7 @@ from scenefab.models.project_file_metadata import (
     ProjectFileMetadata as ProjectMetadata,
 )
 from scenefab.models.project_file_metadata import (
-    _NarrafilmVersion,  # noqa: F401  # re-exported via services.orchestration.__init__
+    _ProjectFileVersion,  # noqa: F401  # re-exported via services.orchestration.__init__
 )
 from scenefab.models.project_models import ProjectType
 
@@ -123,9 +123,10 @@ class ProjectManager:
     负责项目的创建、保存、加载和版本兼容
     """
 
-    # 支持的文件扩展名（.narrafiilm 为旧拼写，保留以兼容已有项目文件）
-    PROJECT_EXTENSION = ".narrafilm"
-    PROJECT_EXTENSIONS = [".narrafilm", ".narrafiilm", ".vfproj"]
+    # 项目文件扩展名（与产品名一致）。.narrafilm/.narrafiilm 为旧拼写，
+    # 保留在加载列表中以兼容已有项目文件。
+    PROJECT_EXTENSION = ".scenefab"
+    PROJECT_EXTENSIONS = [".scenefab", ".narrafilm", ".narrafiilm", ".vfproj"]
 
     def __init__(self):
         self.current_project: SceneFabProject | None = None

--- a/src/scenefab/services/video/monologue_maker.py
+++ b/src/scenefab/services/video/monologue_maker.py
@@ -72,15 +72,15 @@ class MonologueProject(BaseProject):
         return sum(seg.audio_duration for seg in self.segments)
 
     # ------------------------------------------------------------------ #
-    #  持久化 (.narrafilm JSON)                                         #
+    #  持久化 (.scenefab JSON)                                          #
     # ------------------------------------------------------------------ #
 
     def save(self, path: str | None = None) -> str:
         """
-        将项目保存为 .narrafilm 文件（JSON）。
+        将项目保存为 .scenefab 文件（JSON）。
 
         Args:
-            path: 保存路径，默认 <output_dir>/<name>.narrafilm
+            path: 保存路径，默认 <output_dir>/<name>.scenefab
 
         Returns:
             实际保存的文件路径
@@ -88,7 +88,7 @@ class MonologueProject(BaseProject):
         import json
 
         save_path = (
-            Path(path) if path else Path(self.output_dir) / f"{self.name}.narrafilm"
+            Path(path) if path else Path(self.output_dir) / f"{self.name}.scenefab"
         )
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -129,10 +129,10 @@ class MonologueProject(BaseProject):
     @classmethod
     def load(cls, path: str) -> "MonologueProject":
         """
-        从 .narrafilm 文件加载项目（兼容旧 .narrafiilm）。
+        从 .scenefab 文件加载项目（兼容旧 .narrafilm / .narrafiilm）。
 
         Args:
-            path: 项目文件路径（.narrafilm / 旧 .narrafiilm）
+            path: 项目文件路径（.scenefab / 旧 .narrafilm / .narrafiilm）
 
         Returns:
             MonologueProject 实例

--- a/src/scenefab/utils/config.py
+++ b/src/scenefab/utils/config.py
@@ -94,14 +94,20 @@ class ConfigManager:
         if config_dir:
             self.config_dir = Path(config_dir)
         else:
-            # 默认 ~/.narrafilm；若仅存在旧拼写目录 ~/.narrafiilm 则沿用，
+            # 默认 ~/.scenefab（与产品名一致）；若新目录不存在但旧拼写目录
+            # （~/.narrafilm / ~/.narrafiilm）存在，则沿用最先命中的旧目录，
             # 避免孤立既有用户配置/密钥。
-            new_dir = Path.home() / ".narrafilm"
-            legacy_dir = Path.home() / ".narrafiilm"
-            if not new_dir.exists() and legacy_dir.exists():
-                self.config_dir = legacy_dir
-            else:
+            new_dir = Path.home() / ".scenefab"
+            if new_dir.exists():
                 self.config_dir = new_dir
+            else:
+                legacy_dirs = [
+                    Path.home() / ".narrafilm",
+                    Path.home() / ".narrafiilm",
+                ]
+                self.config_dir = next(
+                    (d for d in legacy_dirs if d.exists()), new_dir
+                )
 
         self.config_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/scenefab/utils/secure_config_loader.py
+++ b/src/scenefab/utils/secure_config_loader.py
@@ -47,11 +47,13 @@ class SecureConfigLoader:
         self._load_environment(env_file)
 
         self.allowed_dirs = allowed_dirs or [
-            os.path.expanduser("~/.narrafilm"),
-            os.path.expanduser("~/.narrafiilm"),  # 旧拼写，向后兼容
+            os.path.expanduser("~/.scenefab"),
+            os.path.expanduser("~/.narrafilm"),  # 旧拼写，向后兼容
+            os.path.expanduser("~/.narrafiilm"),  # 更旧拼写，向后兼容
             os.path.expanduser("~/SceneFab"),
-            "/etc/narrafilm",
-            "/etc/narrafiilm",  # 旧拼写，向后兼容
+            "/etc/scenefab",
+            "/etc/narrafilm",  # 旧拼写，向后兼容
+            "/etc/narrafiilm",  # 更旧拼写，向后兼容
             os.path.join(os.path.dirname(__file__), "..", "..", "config"),
         ]
         self.allowed_dirs = [os.path.abspath(d) for d in self.allowed_dirs]

--- a/tests/test_pipeline_project_manager.py
+++ b/tests/test_pipeline_project_manager.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""测试 orchestration.ProjectManager 的 .scenefab 扩展名与向后兼容。"""
+
+import tempfile
+from pathlib import Path
+
+from scenefab.services.orchestration.pipeline_project_manager import ProjectManager
+
+
+class TestProjectExtension:
+    def test_default_extension_is_scenefab(self):
+        assert ProjectManager.PROJECT_EXTENSION == ".scenefab"
+        # 旧拼写保留在加载列表中（向后兼容）
+        assert ".scenefab" in ProjectManager.PROJECT_EXTENSIONS
+        assert ".narrafilm" in ProjectManager.PROJECT_EXTENSIONS
+        assert ".narrafiilm" in ProjectManager.PROJECT_EXTENSIONS
+
+    def test_save_without_suffix_uses_scenefab(self):
+        m = ProjectManager()
+        project = m.create_project(name="t")
+        with tempfile.TemporaryDirectory() as d:
+            out = m.save(project, str(Path(d) / "proj"))
+            assert out.endswith(".scenefab")
+            assert Path(out).exists()
+
+    def test_legacy_extension_preserved_and_loadable(self):
+        m = ProjectManager()
+        project = m.create_project(name="t")
+        with tempfile.TemporaryDirectory() as d:
+            # 显式旧扩展名：在受支持列表内，不被强改后缀
+            out = m.save(project, str(Path(d) / "old.narrafilm"))
+            assert out.endswith(".narrafilm")
+            # 旧文件仍可加载
+            assert m.load(out) is not None


### PR DESCRIPTION
## 概述
项目文件扩展名与配置目录从 `.narrafilm` 统一为 **`.scenefab`**，与产品名一致。**全程向后兼容**，不孤立既有用户文件/配置。

## 改动
- **项目扩展名**：`PROJECT_EXTENSION = ".scenefab"`；`PROJECT_EXTENSIONS = [".scenefab", ".narrafilm", ".narrafiilm", ".vfproj"]`（新文件存 `.scenefab`，旧文件仍可加载）；`monologue_maker.save` 默认后缀同步
- **配置目录**：默认 `~/.scenefab`；新目录不存在但旧 `~/.narrafilm` / `~/.narrafiilm` 存在时沿用最先命中的旧目录
- **安全允许目录**：补 `~/.scenefab` + `/etc/scenefab`，保留旧路径
- **内部符号**：`_NarrafilmVersion` → `_ProjectFileVersion`（产品中立命名）；temp 前缀 `narrafilm_*` → `scenefab_*`

## 向后兼容验证
新增 `test_pipeline_project_manager.py`：默认扩展名 = `.scenefab`、显式旧 `.narrafilm` 保存被保留且可加载。

## 验收
- ruff 通过；mypy 改动文件 0 新增错误
- pytest **600 passed / 11 skipped**

## 待移除（记入 deprecations.md §9）
旧 `.narrafilm` / `.narrafiilm` 扩展名与配置目录兼容读取，建议 v2.3.0 一并移除。