### PR TITLE
fix(ci): publish-pypi 等 build artifacts 全部成功再推

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -61,9 +61,14 @@ jobs:
 
   # ─────────────────────────────────────────────
   # Job 2: 发布到 PyPI
+  # 必须等 build artifacts 全部成功 (create-release) 才推 PyPI.
+  # 这样保证: 只有 Windows/macOS×2/Linux 4 个 PyInstaller 二进制
+  # 全部产出 + GitHub Release 成功创建后, PyPI 才会被推送.
+  # PyPI 不允许同版本覆盖, 一旦推错无法回滚 — 多等 5 分钟换可恢复性
+  # 是值得的.
   # ─────────────────────────────────────────────
   publish-pypi:
-    needs: setup
+    needs: [setup, create-release]
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.setup.outputs.version }}


### PR DESCRIPTION
## 背景

主人说"CI 成功后推 PyPI"。盘现状 `release-build.yml`:

- `publish-pypi` 当前 `needs: setup` — **只** 解析版本号,不验证任何 build 是否成功
- `create-release` `needs: [setup, build-windows, build-macos-x64, build-macos-arm64, build-linux]`
- 两个 job **并行** 跑,publish-pypi 不会等 4 平台 PyInstaller 跑完

**后果**: 即使 4 平台 build 全失败,PyPI 也会推送。

## 修复

`publish-pypi` 改成 `needs: [setup, create-release]` — 等 4 平台 build 全成功 + GitHub Release 页面创建好后才推 PyPI。

## 为什么用 `create-release` 而不是直接 needs 4 个 build jobs

- `create-release` 已经聚合了 5 个 build 的 artifacts(用 `download-artifact` 把 Windows/macOS×2/Linux 的 zip/dmg 全部下载并 attach 到 GitHub Release)
- 验证 GH Release 创建成功 = 隐式验证所有 4 个 build 都成功了
- 比直接 `needs: [setup, build-windows, build-macos-x64, build-macos-arm64, build-linux]` 更稳:顺序更明确,错误信息更清晰
- 满足主人"CI 成功后推 PyPI"的本意

## 不可逆性

PyPI 不允许同版本覆盖,**一旦推错无法回滚**。多等 5 分钟换可恢复性是值得的。

## 验证

- `python -c "import yaml; yaml.safe_load(...)"` → YAML OK
- `publish-pypi needs: ['setup', 'create-release']` ✅
- `create-release needs: ['setup', 'build-windows', 'build-macos-x64', 'build-macos-arm64', 'build-linux']` ✅
- ruff check . → ✅ All checks passed
- pytest → ✅ 636 passed, 10 skipped

## 部署建议

1. merge PR #84 (fix #82 startup)
2. merge 本 PR
3. bump version 2.1.1 → 2.1.2
4. 主人授权后 `git tag v2.1.2 && git push origin v2.1.2`
5. `release-build.yml` 跑: 4 平台 build → create-release → publish-pypi (新依赖) → PyPI 2.1.2 推送
